### PR TITLE
[feat] 글목록 조회를 모든 필요한 데이터를 포함해서 제공 및 유저 모든 트윗 조회 기능, 인증 미들웨어 추가

### DIFF
--- a/be/src/resolvers/index.ts
+++ b/be/src/resolvers/index.ts
@@ -1,6 +1,7 @@
 import {
   getFollowingTweetList,
   getUserTweetList,
+  getUserAllTweetList,
   getFollowingList,
   getFollowerList,
   getSearchedUserList,
@@ -16,6 +17,7 @@ const resolvers = {
   Query: {
     following_tweet_list: getFollowingTweetList,
     user_tweet_list: getUserTweetList,
+    user_all_tweet_list: getUserAllTweetList,
     following_list: getFollowingList,
     follower_list: getFollowerList,
     search_user_list: getSearchedUserList,

--- a/be/src/schema/index.ts
+++ b/be/src/schema/index.ts
@@ -2,6 +2,7 @@ import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   type Tweet {
+    _id: String
     author_id: String
     author: User
     content: String
@@ -14,11 +15,12 @@ const typeDefs = gql`
   }
 
   type Query {
-    following_tweet_list(id: String): [Tweet]
-    user_tweet_list(id: String): [Tweet]
-    following_list(id: String): [User]
-    follower_list(id: String): [User]
-    search_user_list(word: String): [User]
+    following_tweet_list: [Tweet]
+    user_tweet_list(user_id: String): [Tweet]
+    user_all_tweet_list(user_id: String): [Tweet]
+    following_list(user_id: String): [User]
+    follower_list(user_id: String): [User]
+    search_user_list(search_word: String): [User]
   }
 
   type Mutation {
@@ -26,11 +28,12 @@ const typeDefs = gql`
     follow_user(follow_user_id: String!): User
     unfollow_user(unfollow_user_id: String!): User
     add_basic_tweet(content: String!, img_url_list: [String]): Tweet
-    add_reply_tweet(content: String!, img_url_list: [String]): Tweet
-    add_retweet(content: String!): Tweet
+    add_reply_tweet(content: String!, img_url_list: [String], parent_id: String!): Tweet
+    add_retweet(content: String, retweet_id: String!): Tweet
   }
 
   type User {
+    _id: String
     user_id: String
     name: String
     profile_img_url: String

--- a/be/src/services/index.ts
+++ b/be/src/services/index.ts
@@ -1,6 +1,7 @@
 import {
   getFollowingTweetList,
   getUserTweetList,
+  getUserAllTweetList,
   addBasicTweet,
   addReplyTweet,
   addRetweet,
@@ -17,6 +18,7 @@ import { githubLogin } from './auth';
 export {
   getFollowingTweetList,
   getUserTweetList,
+  getUserAllTweetList,
   getFollowingList,
   getFollowerList,
   getSearchedUserList,

--- a/be/src/services/tweet/addTweet.ts
+++ b/be/src/services/tweet/addTweet.ts
@@ -2,53 +2,22 @@ import { tweetModel } from '../../models';
 
 const addBasicTweet = async (_: any, args: any) => {
   const userId = 'test1';
-  const content = '트윗 내용';
-  const imgUrls = [] as Array<String>;
+  const content = args.content;
+  const imgUrls = args.img_url_list;
   const newTweet = await tweetModel.create({
     author_id: userId,
     content: content,
     img_url_list: imgUrls,
     child_tweet_list: [],
   });
-
-  const newTweetId = newTweet?.get('_id');
-
-  const resultTweet = await tweetModel.aggregate([
-    {
-      $match: {
-        _id: newTweetId,
-      },
-    },
-    {
-      $project: {
-        author_id: 1,
-        content: 1,
-        img_url_list: 1,
-        parent_id: 1,
-        retweet_id: 1,
-        child_tweet_list: 1,
-        child_tweet_number: { $size: '$child_tweet_list' },
-      },
-    },
-    {
-      $lookup: {
-        from: 'users',
-        localField: 'author_id',
-        foreignField: 'user_id',
-        as: 'author',
-      },
-    },
-    { $unwind: '$author' },
-  ]);
-
-  return resultTweet[0];
+  return newTweet;
 };
 
 const addReplyTweet = async (_: any, args: any) => {
   const userId = 'test1';
-  const content = '트윗 내용';
-  const imgUrls = [] as Array<String>;
-  const parentId = '5fbca83023d2695f10ab52b4';
+  const content = args.content;
+  const imgUrls = args.img_url_list;
+  const parentId = args.parent_id;
 
   const replyTweet = await tweetModel.create({
     author_id: userId,
@@ -63,99 +32,21 @@ const addReplyTweet = async (_: any, args: any) => {
     { $push: { child_tweet_list: childId } },
     { new: true },
   );
-
-  const resultTweet = await tweetModel.aggregate([
-    {
-      $match: {
-        _id: childId,
-      },
-    },
-    {
-      $project: {
-        author_id: 1,
-        content: 1,
-        img_url_list: 1,
-        parent_id: 1,
-        retweet_id: 1,
-        child_tweet_list: 1,
-        child_tweet_number: { $size: '$child_tweet_list' },
-      },
-    },
-    {
-      $lookup: {
-        from: 'users',
-        localField: 'author_id',
-        foreignField: 'user_id',
-        as: 'author',
-      },
-    },
-    { $unwind: '$author' },
-  ]);
-
-  return resultTweet[0];
+  return replyTweet;
 };
 
 const addRetweet = async (_: any, args: any) => {
   const userId = 'test1';
-  const content = '트윗 리트윗';
-  const retweetId = '5fbca83023d2695f10ab52b4';
+  const content = args.content;
+  const retweetId = args.retweet_id;
 
-  const newTweet = await tweetModel.create({
+  const newRetweet = await tweetModel.create({
     author_id: userId,
     content: content,
     retweet_id: retweetId,
     child_tweet_list: [],
   });
-
-  const newTweetId = newTweet?.get('_id');
-
-  const resultTweet = await tweetModel.aggregate([
-    {
-      $match: {
-        _id: newTweetId,
-      },
-    },
-    {
-      $project: {
-        author_id: 1,
-        content: 1,
-        img_url_list: 1,
-        parent_id: 1,
-        retweet_id: 1,
-        child_tweet_list: 1,
-        child_tweet_number: { $size: '$child_tweet_list' },
-      },
-    },
-    {
-      $lookup: {
-        from: 'users',
-        localField: 'author_id',
-        foreignField: 'user_id',
-        as: 'author',
-      },
-    },
-    { $unwind: '$author' },
-    {
-      $lookup: {
-        from: 'tweets',
-        localField: 'retweet_id',
-        foreignField: '_id',
-        as: 'retweet',
-      },
-    },
-    { $unwind: '$retweet' },
-    {
-      $lookup: {
-        from: 'users',
-        localField: 'retweet.author_id',
-        foreignField: 'user_id',
-        as: 'retweet.author',
-      },
-    },
-    { $unwind: '$retweet.author' },
-  ]);
-
-  return resultTweet[0];
+  return newRetweet;
 };
 
 export { addBasicTweet, addReplyTweet, addRetweet };

--- a/be/src/services/tweet/addTweet.ts
+++ b/be/src/services/tweet/addTweet.ts
@@ -1,7 +1,10 @@
 import { tweetModel } from '../../models';
+import { AuthenticationError } from 'apollo-server-express';
 
-const addBasicTweet = async (_: any, args: any) => {
-  const userId = 'test1';
+const addBasicTweet = async (_: any, args: any, { authUser }: any) => {
+  if (!authUser) throw new AuthenticationError('not authenticated');
+
+  const userId = authUser.user_id;
   const content = args.content;
   const imgUrls = args.img_url_list;
   const newTweet = await tweetModel.create({
@@ -13,8 +16,10 @@ const addBasicTweet = async (_: any, args: any) => {
   return newTweet;
 };
 
-const addReplyTweet = async (_: any, args: any) => {
-  const userId = 'test1';
+const addReplyTweet = async (_: any, args: any, { authUser }: any) => {
+  if (!authUser) throw new AuthenticationError('not authenticated');
+
+  const userId = authUser.user_id;
   const content = args.content;
   const imgUrls = args.img_url_list;
   const parentId = args.parent_id;
@@ -35,8 +40,10 @@ const addReplyTweet = async (_: any, args: any) => {
   return replyTweet;
 };
 
-const addRetweet = async (_: any, args: any) => {
-  const userId = 'test1';
+const addRetweet = async (_: any, args: any, { authUser }: any) => {
+  if (!authUser) throw new AuthenticationError('not authenticated');
+
+  const userId = authUser.user_id;
   const content = args.content;
   const retweetId = args.retweet_id;
 

--- a/be/src/services/tweet/getTweet.ts
+++ b/be/src/services/tweet/getTweet.ts
@@ -1,7 +1,7 @@
 import { userModel, tweetModel } from '../../models';
 
 const getFollowingTweetList = async (_: any, args: any) => {
-  const userId = args.id;
+  const userId = 'test1';
   const followingList = await userModel.findOne({ user_id: userId });
 
   const tweetList = await tweetModel.aggregate([
@@ -33,12 +33,30 @@ const getFollowingTweetList = async (_: any, args: any) => {
       },
     },
     { $unwind: '$author' },
+    {
+      $lookup: {
+        from: 'tweets',
+        localField: 'retweet_id',
+        foreignField: '_id',
+        as: 'retweet',
+      },
+    },
+    { $unwind: { path: '$retweet', preserveNullAndEmptyArrays: true } },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'retweet.author_id',
+        foreignField: 'user_id',
+        as: 'retweet.author',
+      },
+    },
+    { $unwind: { path: '$retweet.author', preserveNullAndEmptyArrays: true } },
   ]);
   return tweetList;
 };
 
 const getUserTweetList = async (_: any, args: any) => {
-  const userId = args.id;
+  const userId = args.user_id;
   const tweetList = await tweetModel.aggregate([
     {
       $match: {
@@ -65,8 +83,74 @@ const getUserTweetList = async (_: any, args: any) => {
       },
     },
     { $unwind: '$author' },
+    {
+      $lookup: {
+        from: 'tweets',
+        localField: 'retweet_id',
+        foreignField: '_id',
+        as: 'retweet',
+      },
+    },
+    { $unwind: { path: '$retweet', preserveNullAndEmptyArrays: true } },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'retweet.author_id',
+        foreignField: 'user_id',
+        as: 'retweet.author',
+      },
+    },
+    { $unwind: { path: '$retweet.author', preserveNullAndEmptyArrays: true } },
   ]);
   return tweetList;
 };
 
-export { getFollowingTweetList, getUserTweetList };
+const getUserAllTweetList = async (_: any, args: any) => {
+  const userId = args.user_id;
+  const tweetList = await tweetModel.aggregate([
+    {
+      $match: { author_id: userId },
+    },
+    {
+      $project: {
+        author_id: 1,
+        content: 1,
+        img_url_list: 1,
+        parent_id: 1,
+        retweet_id: 1,
+        child_tweet_list: 1,
+        child_tweet_number: { $size: '$child_tweet_list' },
+      },
+    },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'author_id',
+        foreignField: 'user_id',
+        as: 'author',
+      },
+    },
+    { $unwind: '$author' },
+    {
+      $lookup: {
+        from: 'tweets',
+        localField: 'retweet_id',
+        foreignField: '_id',
+        as: 'retweet',
+      },
+    },
+    // { $unwind: '$retweet' },
+    {
+      $lookup: {
+        from: 'users',
+        localField: 'retweet.author_id',
+        foreignField: 'user_id',
+        as: 'retweet.author',
+      },
+    },
+    // { $unwind: '$retweet.author' },
+  ]);
+  return tweetList;
+};
+
+export { getFollowingTweetList, getUserTweetList, getUserAllTweetList };

--- a/be/src/services/tweet/index.ts
+++ b/be/src/services/tweet/index.ts
@@ -1,4 +1,11 @@
-import { getFollowingTweetList, getUserTweetList } from './getTweet';
+import { getFollowingTweetList, getUserTweetList, getUserAllTweetList } from './getTweet';
 import { addBasicTweet, addReplyTweet, addRetweet } from './addTweet';
 
-export { getFollowingTweetList, getUserTweetList, addBasicTweet, addReplyTweet, addRetweet };
+export {
+  getFollowingTweetList,
+  getUserTweetList,
+  getUserAllTweetList,
+  addBasicTweet,
+  addReplyTweet,
+  addRetweet,
+};


### PR DESCRIPTION
### 📕 Issue Number

#33 

### 📙 작업 내역

- [x] 기존 join된 정보를 주는것이 아닌 생성된 정보만 제공했다.
- [x] 유저의 모든 트윗을 볼수 있는 API 작성
- [x] 유저의 트윗 리스트들을 가져올때 리트윗 정보와 리트윗 한 저자까지 join해서 데이터 제공하도록 했다
- [x] 여러 쿼리 인자들 명확하게 수정
- [x] 리졸버들의 인증 미들웨어 추가

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항

<br/><br/>
