### PR TITLE
[feat] 하트 캐시 업데이트 부분 수정 및 댓글 시 캐시 업데이트

### DIFF
--- a/fe/src/components/organisms/NotificationContainer/index.tsx
+++ b/fe/src/components/organisms/NotificationContainer/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import Link from 'next/link';
+import { DocumentNode } from 'graphql';
 import { useMyInfo } from '@hooks';
 import { TweetContainer } from '@organisms';
 import { NotificationType } from '@types';
@@ -9,10 +10,14 @@ import FollowContainer from './FollowContainer';
 
 interface Props {
   noti: NotificationType;
+  curTabValue: String;
+  updateQuery: DocumentNode;
 }
 
 const NotificationContainer: FunctionComponent<Props> = ({
-  noti: { giver, tweet, type, _id, curTabValue },
+  noti: { giver, tweet, type, _id },
+  curTabValue,
+  updateQuery,
 }) => {
   const { myProfile } = useMyInfo();
   const isRead = myProfile.lastest_notification_id < _id;
@@ -20,7 +25,7 @@ const NotificationContainer: FunctionComponent<Props> = ({
   if (type === 'mention')
     return (
       <Container color={isRead ? 'rgba(29,161,242,0.1)' : undefined}>
-        <TweetContainer tweet={tweet} />
+        <TweetContainer tweet={tweet} updateQuery={updateQuery} />
       </Container>
     );
 
@@ -43,7 +48,7 @@ const NotificationContainer: FunctionComponent<Props> = ({
       );
     return (
       <Container color={isRead ? 'rgba(29,161,242,0.1)' : undefined}>
-        <TweetContainer tweet={tweet} />
+        <TweetContainer tweet={tweet} updateQuery={updateQuery} />
       </Container>
     );
   }

--- a/fe/src/components/organisms/TweetContainer/index.tsx
+++ b/fe/src/components/organisms/TweetContainer/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const TweetContainer: FunctionComponent<Props> = ({ tweet, updateQuery }) => {
-  const [isHeart, onClickHeart, onClickUnheart] = useHeartState(tweet);
+  const [isHeart, onClickHeart, onClickUnheart] = useHeartState(tweet, updateQuery);
   const [userState] = useUserState(tweet.author);
   const [displayReplyModal, , onClickReplyBtn] = useDisplay(false);
   const [displayRetweetModal, , onClickRetweetBtn] = useDisplay(false);
@@ -85,11 +85,13 @@ const TweetContainer: FunctionComponent<Props> = ({ tweet, updateQuery }) => {
       <ReplyModal
         displayModal={displayReplyModal}
         onClickCloseBtn={onClickReplyBtn}
+        updateQuery={updateQuery}
         tweet={tweet}
       />
       <RetweetModal
         displayModal={displayRetweetModal}
         onClickCloseBtn={onClickRetweetBtn}
+        updateQuery={updateQuery}
         tweet={tweet}
       />
     </>

--- a/fe/src/components/organisms/TweetModal/ReplyModal.tsx
+++ b/fe/src/components/organisms/TweetModal/ReplyModal.tsx
@@ -1,29 +1,41 @@
-/* eslint-disable camelcase */
 import React, { FunctionComponent } from 'react';
+import { DocumentNode } from 'graphql';
 import { useMutation } from '@apollo/client';
 import Markdown from 'react-markdown/with-html';
 import { Modal, TitleSubText } from '@molecules';
 import { NewTweetContainer, MainContainer } from '@organisms';
 import { ADD_REPLY_TWEET } from '@graphql/tweet';
 import { TweetType } from '@types';
+import { binarySearch } from '@libs';
 
 interface Props {
   displayModal: boolean;
   onClickCloseBtn: () => void;
   tweet: TweetType;
+  updateQuery?: DocumentNode;
 }
 
-const TweetReplyModal: FunctionComponent<Props> = ({ displayModal, onClickCloseBtn, tweet }) => {
+const TweetReplyModal: FunctionComponent<Props> = ({
+  displayModal,
+  onClickCloseBtn,
+  tweet,
+  updateQuery,
+}) => {
   const [addReplyTweet, { loading: mutationLoading, error: mutationError }] = useMutation(
     ADD_REPLY_TWEET,
   );
+
   return (
     <Modal displayModal={displayModal} onClickCloseBtn={onClickCloseBtn}>
       <MainContainer userId={tweet.author.user_id} ProfileImgUrl={tweet.author.profile_img_url}>
         <TitleSubText title={tweet.author.name} sub={tweet.author.user_id} />
         <Markdown allowDangerousHtml>{tweet.content}</Markdown>
       </MainContainer>
-      <NewTweetContainer onClickQuery={addReplyTweet} parentId={tweet._id} />
+      <NewTweetContainer
+        onClickQuery={addReplyTweet}
+        parentId={tweet._id}
+        updateQuery={updateQuery}
+      />
     </Modal>
   );
 };

--- a/fe/src/components/organisms/TweetModal/RetweetListModal.tsx
+++ b/fe/src/components/organisms/TweetModal/RetweetListModal.tsx
@@ -11,7 +11,7 @@ interface Props {
   tweetId: string;
 }
 
-const HeartListModal: FunctionComponent<Props> = ({ displayModal, onClickCloseBtn, tweetId }) => {
+const RetweetListModal: FunctionComponent<Props> = ({ displayModal, onClickCloseBtn, tweetId }) => {
   const { loading, error, data } = useQuery(GET_RETWEET_USERLIST, { variables: { tweetId } });
 
   return (
@@ -25,4 +25,4 @@ const HeartListModal: FunctionComponent<Props> = ({ displayModal, onClickCloseBt
   );
 };
 
-export default HeartListModal;
+export default RetweetListModal;

--- a/fe/src/components/organisms/TweetModal/RetweetModal.tsx
+++ b/fe/src/components/organisms/TweetModal/RetweetModal.tsx
@@ -1,6 +1,6 @@
-/* eslint-disable camelcase */
 import React, { FunctionComponent } from 'react';
 import { useMutation } from '@apollo/client';
+import { DocumentNode } from 'graphql';
 import { Modal } from '@molecules';
 import { NewTweetContainer } from '@organisms';
 import { ADD_RETWEET } from '@graphql/tweet';
@@ -10,13 +10,20 @@ interface Props {
   displayModal: boolean;
   onClickCloseBtn: () => void;
   tweet: TweetType;
+  updateQuery?: DocumentNode;
 }
 
-const RetweetModal: FunctionComponent<Props> = ({ displayModal, onClickCloseBtn, tweet }) => {
+const RetweetModal: FunctionComponent<Props> = ({
+  displayModal,
+  onClickCloseBtn,
+  tweet,
+  updateQuery,
+}) => {
   const [addRetweet, { loading: mutationLoading, error: mutationError }] = useMutation(ADD_RETWEET);
+
   return (
     <Modal displayModal={displayModal} onClickCloseBtn={onClickCloseBtn}>
-      <NewTweetContainer tweet={tweet} onClickQuery={addRetweet} />
+      <NewTweetContainer tweet={tweet} onClickQuery={addRetweet} updateQuery={updateQuery} />
     </Modal>
   );
 };

--- a/fe/src/components/organisms/index.ts
+++ b/fe/src/components/organisms/index.ts
@@ -4,7 +4,7 @@ import MainContainer from './MainContainer';
 import NewTweetContainer from './NewTweetContainer';
 import NotificationContainer from './NotificationContainer';
 import PageLayout from './PageLayout';
-import RetweetContainer from './RetweetContainer';
+import RetweetContainer from './ReTweetContainer';
 import SideBar from './SideBar';
 import SignupModal from './SignupModal';
 import TweetContainer from './TweetContainer';

--- a/fe/src/graphql/tweet/getTweet.gql
+++ b/fe/src/graphql/tweet/getTweet.gql
@@ -101,6 +101,21 @@ query GET_TWEET_DETAIL($tweetId: String!) {
     child_tweet_number
     retweet_user_number
     heart_user_number
+    retweet_id
+    img_url_list
+    retweet {
+      _id
+      content
+      child_tweet_number
+      retweet_user_number
+      heart_user_number
+      img_url_list
+      author {
+        user_id
+        name
+        profile_img_url
+      }
+    }
     author {
       user_id
       name
@@ -118,6 +133,7 @@ query GET_CHILD_TWEETLIST($tweetId: String!, $oldestTweetId: String) {
     retweet_user_number
     heart_user_number
     retweet_id
+    img_url_list
     retweet {
       _id
       content

--- a/fe/src/hooks/useHeartState.ts
+++ b/fe/src/hooks/useHeartState.ts
@@ -17,6 +17,7 @@ const useHeartState = (
 ): [boolean, () => Promise<void>, () => Promise<void>] => {
   const { data } = useQuery(GET_MYINFO);
   const [isHeart, setIsHeart] = useState(getIsHeart(tweet, data?.myProfile));
+  const [state, setState] = useState(false);
 
   const [heartTweet] = useMutation(HEART_TWEET);
   const [unheartTweet] = useMutation(UNHEART_TWEET);
@@ -30,70 +31,78 @@ const useHeartState = (
   };
 
   const onClickHeart = async () => {
-    await heartTweet({
-      variables: { tweet_id: tweet._id },
-      update: (cache) => {
-        const userInfo = cache.readQuery({ query: GET_MYINFO });
-        cache.writeQuery({
-          query: GET_MYINFO,
-          data: {
-            myProfile: {
-              ...userInfo.myProfile,
-              heart_tweet_id_list: [...userInfo.myProfile.heart_tweet_id_list, tweet._id],
+    if (!state) {
+      setState(true);
+      await heartTweet({
+        variables: { tweet_id: tweet._id },
+        update: (cache) => {
+          const userInfo = cache.readQuery({ query: GET_MYINFO });
+          cache.writeQuery({
+            query: GET_MYINFO,
+            data: {
+              myProfile: {
+                ...userInfo.myProfile,
+                heart_tweet_id_list: [...userInfo.myProfile.heart_tweet_id_list, tweet._id],
+              },
             },
-          },
-        });
-        const res = cache.readQuery({ query: updateQuery });
-        const source = [...res.tweetList];
-        const idx = binarySearch(source, tweet._id);
-        if (idx === -1) return;
-        const number: number = source[idx].heart_user_number + 1;
-        source[idx] = {
-          ...source[idx],
-          heart_user_number: number,
-        };
-        cache.writeQuery({
-          query: updateQuery,
-          data: { tweetList: source },
-        });
-      },
-    });
-    setHeartTweet();
+          });
+          const res = cache.readQuery({ query: updateQuery });
+          const source = [...res.tweetList];
+          const idx = binarySearch(source, tweet._id);
+          if (idx === -1) return;
+          const number: number = source[idx].heart_user_number + 1;
+          source[idx] = {
+            ...source[idx],
+            heart_user_number: number,
+          };
+          cache.writeQuery({
+            query: updateQuery,
+            data: { tweetList: source },
+          });
+        },
+      });
+      setHeartTweet();
+      setState(false);
+    }
   };
 
   const onClickUnheart = async () => {
-    await unheartTweet({
-      variables: { tweet_id: tweet._id },
-      update: (cache) => {
-        const userInfo = cache.readQuery({ query: GET_MYINFO });
-        const arr = [...userInfo.myProfile.heart_tweet_id_list];
-        const index = arr.indexOf(tweet._id);
-        arr.splice(index, 1);
-        cache.writeQuery({
-          query: GET_MYINFO,
-          data: {
-            myProfile: {
-              ...userInfo.myProfile,
-              heart_tweet_id_list: arr,
+    if (!state) {
+      setState(true);
+      await unheartTweet({
+        variables: { tweet_id: tweet._id },
+        update: (cache) => {
+          const userInfo = cache.readQuery({ query: GET_MYINFO });
+          const arr = [...userInfo.myProfile.heart_tweet_id_list];
+          const index = arr.indexOf(tweet._id);
+          arr.splice(index, 1);
+          cache.writeQuery({
+            query: GET_MYINFO,
+            data: {
+              myProfile: {
+                ...userInfo.myProfile,
+                heart_tweet_id_list: arr,
+              },
             },
-          },
-        });
-        const res = cache.readQuery({ query: updateQuery });
-        const source = [...res.tweetList];
-        const idx = binarySearch(source, tweet._id);
-        if (idx === -1) return;
-        const number: number = source[idx].heart_user_number - 1;
-        source[idx] = {
-          ...source[idx],
-          heart_user_number: number,
-        };
-        cache.writeQuery({
-          query: updateQuery,
-          data: { tweetList: source },
-        });
-      },
-    });
-    setUnheartTweet();
+          });
+          const res = cache.readQuery({ query: updateQuery });
+          const source = [...res.tweetList];
+          const idx = binarySearch(source, tweet._id);
+          if (idx === -1) return;
+          const number: number = source[idx].heart_user_number - 1;
+          source[idx] = {
+            ...source[idx],
+            heart_user_number: number,
+          };
+          cache.writeQuery({
+            query: updateQuery,
+            data: { tweetList: source },
+          });
+        },
+      });
+      setUnheartTweet();
+      setState(false);
+    }
   };
 
   useEffect(() => {

--- a/fe/src/libs/index.tsx
+++ b/fe/src/libs/index.tsx
@@ -1,5 +1,5 @@
-import { getJSXwithUserState, makeTimeText } from './utility';
+import { getJSXwithUserState, makeTimeText, binarySearch } from './utility';
 import apolloClient from './apolloClient';
 import AuthProvider from './authProvider';
 
-export { getJSXwithUserState, makeTimeText, apolloClient, AuthProvider };
+export { getJSXwithUserState, makeTimeText, apolloClient, AuthProvider, binarySearch };

--- a/fe/src/libs/utility.ts
+++ b/fe/src/libs/utility.ts
@@ -21,4 +21,16 @@ const makeTimeText = (pastTime: string) => {
   return timeString;
 };
 
-export { getJSXwithUserState, makeTimeText };
+const binarySearch = (arr: any, id: string) => {
+  let left = 0;
+  let right = arr.length - 1;
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    if (arr[mid]._id < id) right = mid - 1;
+    else if (arr[mid]._id > id) left = mid + 1;
+    else return mid;
+  }
+  return -1;
+};
+
+export { getJSXwithUserState, makeTimeText, binarySearch };

--- a/fe/src/pages/notifications/[[...type]].tsx
+++ b/fe/src/pages/notifications/[[...type]].tsx
@@ -23,7 +23,6 @@ const Notification: FunctionComponent = () => {
   const { type } = router.query;
   const queryArr = { all: GET_NOTIFICATION_LIST, mention: GET_MENTION_NOTIFICATION_LIST };
   const value = getValue(type);
-  // type ? type[0] : 'all';
   const { data, fetchMore } = useQuery(queryArr[value]);
   const [mutate] = useMutation(CONFIRM_NOTIFICATION);
 
@@ -86,7 +85,12 @@ const Notification: FunctionComponent = () => {
       <TabBar value={value} handleChange={onClick} labels={['all', 'mention']} />
       <>
         {notificationList?.map((noti: NotificationType, index: number) => (
-          <NotificationContainer key={index} noti={{ ...noti, curTabValue: value }} />
+          <NotificationContainer
+            key={index}
+            noti={noti}
+            curTabValue={value}
+            updateQuery={queryArr[value]}
+          />
         ))}
       </>
       <div ref={fetchMoreEl} />


### PR DESCRIPTION
### 📕 Issue Number

Close #

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 하트 클릭시 캐시 업데이트 하는 부분 수정 ( 이진 탐색을 사용하여 빠른시간에 캐시 업데이트, 더블클릭 이슈 해결)
- [x] 댓글 입력시 캐시 업데이트
- [x] 리트윗 시 캐시 업데이트 ( 캐시 업데이트 되었다가, 리트윗 된 글을 다시 받아오면 리트윗 수, 하트 수, 댓글 수가 null 로 바뀌는 에러 발생, 아직 해결 X)

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 리트윗시 새글 이 pull 당겨져 왔을 때, 리트윗 개수가 업데이트 된 트윗의 하트, 리트윗, 댓글 수가 모두 null 로 바뀌는 이슈 발생, 왜 바뀌는지 이유를 아직 알지 못함.

<br/><br/>
