### PR TITLE
[fix] 트윗 삭제시  child list, retweet list 가 제거되지 않는 이슈 해결

### DIFF
--- a/be/src/app.ts
+++ b/be/src/app.ts
@@ -16,18 +16,19 @@ dotenv.config();
 
 const app = express();
 
+const corsOptions = { origin: 'http://localhost:3000', credentials: true };
+
 app.use(cookieParser());
 app.use(logger('dev'));
 app.use(express.static(path.join(__dirname, '../uploads')));
-
+app.use(cors(corsOptions));
 const port: number = Number(process.env.PORT) || 3000;
-const corsOptions = { origin: 'http://localhost:3000', credentials: true };
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   context: ({ req, res }) => {
-    if (!req.cookies.jwt) return { authUser: undefined };
+    if (!req.cookies.jwt) return { authUser: undefined, res };
 
     const authUser = verifyToken(req.cookies.jwt);
     return { authUser, res };

--- a/be/src/services/tweet/deleteTweet.ts
+++ b/be/src/services/tweet/deleteTweet.ts
@@ -15,13 +15,15 @@ const deleteTweet = async (_: any, { tweet_id }: Args, { authUser }: Auth) => {
 
   const willDeletedTweet = await tweetModel.findOne({ author_id: userId, _id: tweet_id });
 
-  const retweetId = willDeletedTweet?.get('reweet_id');
+  const retweetId = willDeletedTweet?.get('retweet_id');
 
-  if (retweetId) await willDeletedTweet?.updateOne({ $pull: { retweet_user_id_list: retweetId } });
+  if (retweetId)
+    await tweetModel.updateOne({ _id: retweetId }, { $pull: { retweet_user_id_list: userId } });
 
   const parentId = willDeletedTweet?.get('parent_id');
 
-  if (parentId) await willDeletedTweet?.updateOne({ parent_id: parentId });
+  if (parentId)
+    await tweetModel.updateOne({ _id: parentId }, { $pull: { child_tweet_id_list: tweet_id } });
 
   const heart_user_id_list = willDeletedTweet?.get('heart_user_id_list');
 

--- a/be/src/services/tweet/getTweet.ts
+++ b/be/src/services/tweet/getTweet.ts
@@ -1,7 +1,7 @@
 import { AuthenticationError } from 'apollo-server-express';
 import { userModel, tweetModel } from '@models';
-import commonReadCondition from './common';
 import { stringToObjectId } from '@libs/utiltys';
+import commonReadCondition from './common';
 
 interface Auth {
   authUser: { id: string };


### PR DESCRIPTION
### 📕 Issue Number

Close #

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 트윗 삭제시 child list, retweet list 가 제거되지 않는 이슈 해결

### 📘 작업 유형

- [] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현재 리트윗 아이디에 사용자의 아이디가 들어있는데, 글의 아이디가 들어가야 될 것 같습니다. 아니면 하트처럼 하나의 글에 한사람당 하나의 리트윗 만 가능하도록 바꾸어야 할 것 같습니다!


<br/><br/>
