### PR TITLE
[feat] 무한 스크롤 데이터와 함께 사용하는 커스텀 훅 및 여러 커스텀 훅 생성, 검색 페이지, 트윗 디테일 페이지 서버 사이드 렌더링

### DIFF
--- a/fe/src/components/organisms/SideBar/index.tsx
+++ b/fe/src/components/organisms/SideBar/index.tsx
@@ -50,7 +50,7 @@ const SideBar: FunctionComponent = () => {
   const variables = { id: myProfile ? myProfile.lastest_notification_id : undefined };
   const { data } = useQuery(GET_NOTIFICATION_COUNT, {
     variables,
-    pollInterval: 1000,
+    pollInterval: 60 * 1000,
   });
 
   const onKeyDown = (e: any) => {

--- a/fe/src/components/organisms/TweetDetailContainer/index.tsx
+++ b/fe/src/components/organisms/TweetDetailContainer/index.tsx
@@ -3,11 +3,17 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Markdown from 'react-markdown/with-html';
 import { useQuery, useMutation } from '@apollo/client';
-import { TitleSubText, IconButton, Loading, UserInfo } from '@molecules';
+import { TitleSubText, IconButton, Loading, UserInfo, UploadImg } from '@molecules';
 import { Text, Heart, Comment, Retweet, X } from '@atoms';
 import { useHeartState, useDisplay, useDisplayWithShallow, useUserState } from '@hooks';
 import { makeTimeText } from '@libs';
-import { HeartListModal, RetweetListModal, ReplyModal, RetweetModal } from '@organisms';
+import {
+  HeartListModal,
+  RetweetListModal,
+  ReplyModal,
+  RetweetModal,
+  RetweetContainer,
+} from '@organisms';
 import { DELETE_TWEET, GET_TWEET_DETAIL } from '@graphql/tweet';
 import { QueryVariableType } from '@types';
 import {
@@ -23,7 +29,7 @@ interface Props {
   tweetId: string;
 }
 
-const TweetDetailContainer: FunctionComponent<Props> = ({ children, tweetId }) => {
+const TweetDetailContainer: FunctionComponent<Props> = ({ children, stweet, tweetId }) => {
   const router = useRouter();
   const queryVariable: QueryVariableType = { variables: { tweetId: tweetId as string } };
   const { loading, error, data } = useQuery(GET_TWEET_DETAIL, queryVariable);
@@ -69,6 +75,12 @@ const TweetDetailContainer: FunctionComponent<Props> = ({ children, tweetId }) =
           {userState === 'me' ? <IconButton icon={X} onClick={onClickDeleteBtn} /> : <></>}
         </TweetHeaderContainer>
         <Markdown allowDangerousHtml>{tweet.content}</Markdown>
+        {tweet.retweet?._id ? <RetweetContainer tweet={tweet.retweet} /> : <></>}
+        {tweet.img_url_list && tweet.img_url_list[0] ? (
+          <UploadImg img={tweet.img_url_list[0]} />
+        ) : (
+          ''
+        )}
         <TimeContainer>
           <Text styled="sub" size="15px" value={makeTimeText(tweet.createAt)} />
         </TimeContainer>

--- a/fe/src/hooks/index.ts
+++ b/fe/src/hooks/index.ts
@@ -6,6 +6,9 @@ import useMyInfo from './useMyInfo';
 import useOnTabChange from './useOnTabChange';
 import useOnTextChange from './useOnTextChange';
 import useUserState from './useUserState';
+import useTypeRouter from './useTypeRouter';
+import useDataWithInfiniteScroll from './useDataWithInfiniteScroll';
+import useHomeTweetListInfiniteScroll from './useHomeTweetListInfiniteScroll';
 
 export {
   useDisplay,
@@ -16,4 +19,7 @@ export {
   useOnTabChange,
   useOnTextChange,
   useUserState,
+  useTypeRouter,
+  useDataWithInfiniteScroll,
+  useHomeTweetListInfiniteScroll,
 };

--- a/fe/src/hooks/useDataWithInfiniteScroll.ts
+++ b/fe/src/hooks/useDataWithInfiniteScroll.ts
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { useQuery } from '@apollo/client';
+import { useInfiniteScroll } from '@hooks';
+
+const useDataWithInfiniteScroll = (
+  variableTarget: string,
+  variableValue: string,
+  moreVariableTarget: string,
+  dataTarget: string,
+  updateQuery: any,
+  fetchMoreEl: React.MutableRefObject<null>,
+) => {
+  const queryVariable = { variables: { [variableTarget]: variableValue } };
+  const { data, fetchMore } = useQuery(updateQuery, queryVariable);
+  const { _id: bottomId } = data?.[dataTarget][data?.[dataTarget].length - 1] || {};
+  const [intersecting] = useInfiniteScroll(fetchMoreEl);
+
+  useEffect(() => {
+    const asyncEffect = async () => {
+      if (!intersecting || !bottomId || !fetchMore) return;
+      const { data: fetchMoreData } = await fetchMore({
+        variables: { [moreVariableTarget]: bottomId },
+      });
+    };
+    asyncEffect();
+  }, [intersecting]);
+
+  return [data];
+};
+
+export default useDataWithInfiniteScroll;

--- a/fe/src/hooks/useDisplayWithShallow.ts
+++ b/fe/src/hooks/useDisplayWithShallow.ts
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { useRouter } from 'next/router';
+import { useTypeRouter } from '@hooks';
 
 const useDisplayWithShallow = (routeName: string): [boolean, () => void, () => void] => {
-  const router = useRouter();
-  const { type } = router.query;
+  const [type, router] = useTypeRouter();
   const tweetId = type ? type[0] : '';
   const currentRoute = type ? type[1] : '';
   const [display, setDisplay] = useState(currentRoute === routeName);

--- a/fe/src/hooks/useHomeTweetListInfiniteScroll.ts
+++ b/fe/src/hooks/useHomeTweetListInfiniteScroll.ts
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { useQuery } from '@apollo/client';
+import { useInfiniteScroll } from '@hooks';
+import { GET_TWEETLIST } from '@graphql/tweet';
+
+const useHomeTweetInfiniteScroll = (fetchMoreEl: React.MutableRefObject<null>) => {
+  const { data, fetchMore } = useQuery(GET_TWEETLIST);
+  const { _id: topTweetId } = data?.tweetList[0] || {};
+  const { _id: bottomTweetId } = data?.tweetList[data?.tweetList.length - 1] || {};
+  useQuery(GET_TWEETLIST, {
+    variables: { latestTweetId: topTweetId },
+    pollInterval: 60 * 1000,
+  });
+
+  const [intersecting, loadFinished, setLoadFinished] = useInfiniteScroll(fetchMoreEl);
+
+  useEffect(() => {
+    const asyncEffect = async () => {
+      if (!intersecting || loadFinished || !bottomTweetId || !fetchMore) return;
+      const { data: fetchMoreData } = await fetchMore({
+        variables: { oldestTweetId: bottomTweetId },
+      });
+      if (fetchMoreData.tweetList.length < 20) setLoadFinished(true);
+    };
+    asyncEffect();
+  }, [intersecting]);
+
+  return [data];
+};
+
+export default useHomeTweetInfiniteScroll;

--- a/fe/src/hooks/useInfiniteScroll.ts
+++ b/fe/src/hooks/useInfiniteScroll.ts
@@ -1,11 +1,10 @@
 import React, { useCallback, useState, useRef, useEffect } from 'react';
 
 const useInfiniteScroll = (
-  targetEl: any,
-  ssr = false,
+  targetEl: React.MutableRefObject<null>,
 ): [boolean, boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
   const observerRef = useRef<IntersectionObserver | null>(null);
-  const isFirstRender = useRef(!ssr);
+  const isFirstRender = useRef(true);
   const [isIntersecting, setIntersecting] = useState(false);
   const [loadFinished, setLoadFinished] = useState(false);
 

--- a/fe/src/hooks/useTypeRouter.ts
+++ b/fe/src/hooks/useTypeRouter.ts
@@ -1,0 +1,8 @@
+import { NextRouter, useRouter } from 'next/router';
+
+const useTypeRouter = (): [string | string[] | undefined, NextRouter] => {
+  const router = useRouter();
+  const { type } = router.query;
+  return [type, router];
+};
+export default useTypeRouter;

--- a/fe/src/libs/index.tsx
+++ b/fe/src/libs/index.tsx
@@ -1,5 +1,12 @@
-import { getJSXwithUserState, makeTimeText, binarySearch } from './utility';
+import { getJSXwithUserState, makeTimeText, binarySearch, getJWTFromBrowser } from './utility';
 import apolloClient from './apolloClient';
 import AuthProvider from './authProvider';
 
-export { getJSXwithUserState, makeTimeText, apolloClient, AuthProvider, binarySearch };
+export {
+  getJSXwithUserState,
+  makeTimeText,
+  apolloClient,
+  AuthProvider,
+  binarySearch,
+  getJWTFromBrowser,
+};

--- a/fe/src/libs/utility.ts
+++ b/fe/src/libs/utility.ts
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from 'react';
 import TimeAgo from 'javascript-time-ago';
+import Cookies from 'cookies';
 
 // English.
 import en from 'javascript-time-ago/locale/en';
@@ -33,4 +33,9 @@ const binarySearch = (arr: any, id: string) => {
   return -1;
 };
 
-export { getJSXwithUserState, makeTimeText, binarySearch };
+const getJWTFromBrowser = (req: any, res: any) => {
+  const cookies = new Cookies(req, res);
+  return cookies.get('jwt');
+};
+
+export { getJSXwithUserState, makeTimeText, binarySearch, getJWTFromBrowser };

--- a/fe/src/pages/explore/[[...type]].tsx
+++ b/fe/src/pages/explore/[[...type]].tsx
@@ -1,28 +1,40 @@
 import React, { FunctionComponent, useState, useEffect, useRef } from 'react';
-import { useQuery } from '@apollo/client';
-import { useRouter } from 'next/router';
 import { SearchBar, TabBar, Loading } from '@molecules';
 import { PageLayout, TweetContainer, UserCard } from '@organisms';
-import { useOnTextChange, useInfiniteScroll } from '@hooks';
-import { apolloClient } from '@libs';
+import { useOnTextChange, useTypeRouter, useDataWithInfiniteScroll } from '@hooks';
+import { apolloClient, getJWTFromBrowser } from '@libs';
 import { GET_SEARCH_TWEETLIST } from '@graphql/tweet';
 import { GET_SEARCH_USERLIST } from '@graphql/user';
-import { TweetType, VariableType } from '@types';
+import { TweetType, UserType } from '@types';
 
 const Explore: FunctionComponent = () => {
-  const router = useRouter();
-  const { type } = router.query;
+  const [type, router] = useTypeRouter();
+  const value = type ? type[0] : 'tweets';
+
   const [textValue, setTextValue, onTextChange] = useOnTextChange(type ? type[1] || '' : '');
   const [searchWord, setSearchWord] = useState(textValue);
-  const value = type ? type[0] : 'tweets';
-  const queryArr = { tweets: GET_SEARCH_TWEETLIST, people: GET_SEARCH_USERLIST };
-  const variable: VariableType = { searchWord };
-  const { loading, error, data, fetchMore } = useQuery(queryArr[value], {
-    variables: variable,
-  });
-  const { _id: bottomId } = data?.searchList?.[data?.searchList?.length - 1] || {};
   const fetchMoreEl = useRef(null);
-  const [intersecting] = useInfiniteScroll(fetchMoreEl);
+
+  const keyValue = {
+    tweets: [
+      'searchWord',
+      searchWord,
+      'oldestTweetId',
+      'searchList',
+      GET_SEARCH_TWEETLIST,
+      fetchMoreEl,
+    ],
+    people: [
+      'searchWord',
+      searchWord,
+      'oldestUserId',
+      'searchList',
+      GET_SEARCH_USERLIST,
+      fetchMoreEl,
+    ],
+  };
+
+  const [data] = useDataWithInfiniteScroll(...keyValue[value]);
 
   const onKeyDown = (e: any) => {
     if (e.key === 'Enter') {
@@ -47,17 +59,6 @@ const Explore: FunctionComponent = () => {
     }
   };
 
-  useEffect(() => {
-    const asyncEffect = async () => {
-      if (!intersecting || !bottomId || !fetchMore) return;
-      const newVariable =
-        value === 'tweets' ? { oldestTweetId: bottomId } : { oldestUserId: bottomId };
-      const mergeVariable = { ...variable, ...newVariable };
-      const { data: fetchMoreData } = await fetchMore({ variables: mergeVariable });
-    };
-    asyncEffect();
-  }, [intersecting]);
-
   return (
     <PageLayout>
       <SearchBar
@@ -73,11 +74,11 @@ const Explore: FunctionComponent = () => {
       <div>
         {data ? (
           value === 'tweets' ? (
-            data.searchList?.map((tweet: Tweet, index: number) => (
+            data.searchList?.map((tweet: TweetType, index: number) => (
               <TweetContainer key={index} tweet={tweet} updateQuery={GET_SEARCH_TWEETLIST} />
             ))
           ) : (
-            data.searchList?.map((user: User, index: number) => (
+            data.searchList?.map((user: UserType, index: number) => (
               <UserCard key={index} user={user} />
             ))
           )
@@ -91,3 +92,22 @@ const Explore: FunctionComponent = () => {
 };
 
 export default Explore;
+
+export async function getServerSideProps({ req, res }) {
+  const jwt = getJWTFromBrowser(req, res);
+
+  await apolloClient.query({
+    query: GET_SEARCH_TWEETLIST,
+    variables: { searchWord: '' },
+    context: {
+      headers: { cookie: `jwt=${jwt}` },
+    },
+  });
+  const initialState = apolloClient.cache.extract();
+
+  return {
+    props: {
+      initialState,
+    },
+  };
+}

--- a/fe/src/pages/status/[[...type]].tsx
+++ b/fe/src/pages/status/[[...type]].tsx
@@ -1,38 +1,28 @@
-import React, { FunctionComponent, useState, useEffect, useRef } from 'react';
-import { useQuery } from '@apollo/client';
-import { useRouter } from 'next/router';
+import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { Loading } from '@molecules';
 import { PageLayout, TweetContainer, TweetDetailContainer } from '@organisms';
-import { useInfiniteScroll } from '@hooks';
-import { apolloClient } from '@libs';
-import { TweetType, QueryVariableType } from '@types';
+import { useTypeRouter, useDataWithInfiniteScroll } from '@hooks';
+import { apolloClient, getJWTFromBrowser } from '@libs';
+import { TweetType } from '@types';
+import { GET_CHILD_TWEETLIST, GET_TWEET_DETAIL } from '@graphql/tweet';
 
-import { GET_CHILD_TWEETLIST } from '@graphql/tweet';
-
-const UserDetail: FunctionComponent = () => {
-  const router = useRouter();
-  const { type } = router.query;
+const TweetDetail: FunctionComponent = () => {
+  const [type] = useTypeRouter();
   const tweetId = type ? type[0] : '';
-  const queryVariable: QueryVariableType = { variables: { tweetId: tweetId as string } };
-  const { loading, error, data, fetchMore } = useQuery(GET_CHILD_TWEETLIST, queryVariable);
-  const { _id: bottomTweetId } = data?.tweetList[data?.tweetList.length - 1] || {};
+
   const fetchMoreEl = useRef(null);
-  const [intersecting, loadFinished, setLoadFinished] = useInfiniteScroll(fetchMoreEl);
+  const [data] = useDataWithInfiniteScroll(
+    'tweetId',
+    tweetId,
+    'oldestTweetId',
+    'tweetList',
+    GET_CHILD_TWEETLIST,
+    fetchMoreEl,
+  );
 
   useEffect(() => {
     apolloClient.cache.evict({ id: 'ROOT_QUERY', fieldName: 'child_tweet_list' });
   }, [tweetId]);
-
-  useEffect(() => {
-    const asyncEffect = async () => {
-      if (!intersecting || loadFinished || !bottomTweetId || !fetchMore) return;
-      const { data: fetchMoreData } = await fetchMore({
-        variables: { oldestTweetId: bottomTweetId },
-      });
-      if (fetchMoreData.tweetList.length < 20) setLoadFinished(true);
-    };
-    asyncEffect();
-  }, [intersecting]);
 
   return (
     <PageLayout>
@@ -49,4 +39,32 @@ const UserDetail: FunctionComponent = () => {
   );
 };
 
-export default UserDetail;
+export default TweetDetail;
+
+export async function getServerSideProps({ req, res, query }) {
+  const tweetId = query.type[0];
+  const jwt = getJWTFromBrowser(req, res);
+
+  await apolloClient.query({
+    query: GET_TWEET_DETAIL,
+    variables: { tweetId },
+    context: {
+      headers: { cookie: `jwt=${jwt}` },
+    },
+  });
+
+  await apolloClient.query({
+    query: GET_CHILD_TWEETLIST,
+    variables: { tweetId },
+    context: {
+      headers: { cookie: `jwt=${jwt}` },
+    },
+  });
+  const initialState = apolloClient.cache.extract();
+
+  return {
+    props: {
+      initialState,
+    },
+  };
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #

### 📙 작업 내역

- [x] 무한 스크롤 데이터 커스텀 훅 생성
- [x] 양방향 무한 스크롤 데이터 커스텀 훅 생성
- [x] 여러 커스텀 훅 및 유틸리티 함수 생성
- [x] 검색 페이지 및 트윗 디테일 페이지 서버 사이드 렌더링 
- [x] 트윗 디테일 페이지에서 이미지 및 리트윗 출력

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항



<br/><br/>
