### PR TITLE
[fix] 프로필 페이지 글 쓰기 캐시 업데이트 및 댓글시 트윗 사라지는 에러 수정

### DIFF
--- a/fe/src/components/organisms/NewTweetContainer/index.tsx
+++ b/fe/src/components/organisms/NewTweetContainer/index.tsx
@@ -57,7 +57,7 @@ const NewTweetContainer: FunctionComponent<Props> = ({
     let source;
     if (updateQuery.object) {
       source = { ...tweet };
-      const number = source[type] || 0 + 1;
+      const number = source[type] + 1;
       source = { ...source, [type]: number };
     } else {
       const res = cache.readQuery<{ tweetList: TweetType[] }>(query);
@@ -72,9 +72,10 @@ const NewTweetContainer: FunctionComponent<Props> = ({
         };
       }
     }
+
     cache.writeQuery({
-      query: updateQuery.query,
-      variables: updateQuery.variables,
+      query: query.query,
+      variables: query.variables,
       data: { tweetList: source },
     });
   };

--- a/fe/src/components/organisms/PageLayout/index.tsx
+++ b/fe/src/components/organisms/PageLayout/index.tsx
@@ -1,16 +1,18 @@
 import React, { FunctionComponent, ReactChild } from 'react';
 import { SideBar } from '@organisms';
+import { DocumentNode } from 'graphql';
 import { Container, MainContainer } from './styled';
 
 interface Props {
   children: ReactChild[];
   page?: string;
+  updateQuery?: { query: DocumentNode; variables?: {} };
 }
 
-const PageLayout: FunctionComponent<Props> = ({ children, page }) => {
+const PageLayout: FunctionComponent<Props> = ({ children, page, updateQuery }) => {
   return (
     <Container>
-      <SideBar page={page} />
+      <SideBar page={page} updateQuery={updateQuery} />
       <MainContainer>{children}</MainContainer>
     </Container>
   );

--- a/fe/src/components/organisms/SideBar/index.tsx
+++ b/fe/src/components/organisms/SideBar/index.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, FunctionComponent, useState } from 'react';
 import { useQuery } from '@apollo/client';
 import { ListItem } from '@material-ui/core';
 import { useRouter } from 'next/router';
+import { DocumentNode } from 'graphql';
 import Link from 'next/link';
 import { Button, UserPopover, UserInfo, SearchBar } from '@molecules';
 import { Home, Explore, Twitter, Notifications, Profiles } from '@atoms';
@@ -10,7 +11,7 @@ import { NewTweetModal } from '@organisms';
 import { GET_NOTIFICATION_COUNT } from '@graphql/notification';
 import Container from './styled';
 
-const ONE_MINUTE = 60 * 1000;
+const TEN_SECONDS = 10 * 1000;
 
 interface ButtonProps {
   id: number;
@@ -50,9 +51,10 @@ const TITLE: Array<ButtonProps> = [
 
 interface Props {
   page?: string;
+  updateQuery?: { query: DocumentNode; variables?: {} };
 }
 
-const SideBar: FunctionComponent<Props> = ({ page }) => {
+const SideBar: FunctionComponent<Props> = ({ page, updateQuery }) => {
   const router = useRouter();
   const { myProfile } = useMyInfo();
   const [value, , onTextChange] = useOnTextChange('');
@@ -61,7 +63,7 @@ const SideBar: FunctionComponent<Props> = ({ page }) => {
   const variables = { id: myProfile ? myProfile.lastest_notification_id : undefined };
   const { data } = useQuery(GET_NOTIFICATION_COUNT, {
     variables,
-    pollInterval: ONE_MINUTE,
+    pollInterval: TEN_SECONDS,
   });
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -73,13 +75,12 @@ const SideBar: FunctionComponent<Props> = ({ page }) => {
   const userId: string = myProfile.user_id;
   const userName: string = myProfile.name;
   const userProfileImg: string = myProfile.profile_img_url;
-  if (data) TITLE[3].text = `알림 ${data.count ? data.count.count : ''}`;
+  if (data) TITLE[3].text = `알림 ${data.count.count !== 0 ? data.count.count : ''}`;
   TITLE[4].link = `/${userId}`;
   TITLE[5].onClick = onClickTweetBtn;
 
   const placeholder = 'Search Twitter';
   const type = 'text';
-  const variant = 'standard';
 
   return (
     <>
@@ -125,7 +126,11 @@ const SideBar: FunctionComponent<Props> = ({ page }) => {
           <UserInfo title={userName} sub={userId} img={userProfileImg} width="90%" />
         </ListItem>
       </Container>
-      <NewTweetModal displayModal={displayModal} onClickCloseBtn={onClickTweetBtn} />
+      <NewTweetModal
+        displayModal={displayModal}
+        onClickCloseBtn={onClickTweetBtn}
+        updateQuery={updateQuery}
+      />
     </>
   );
 };

--- a/fe/src/components/organisms/TweetModal/NewTweetModal.tsx
+++ b/fe/src/components/organisms/TweetModal/NewTweetModal.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { useMutation } from '@apollo/client';
+import { DocumentNode } from 'graphql';
 import { Modal } from '@molecules';
 import { NewTweetContainer } from '@organisms';
 import { ADD_BASIC_TWEET } from '@graphql/tweet';
@@ -7,15 +8,24 @@ import { ADD_BASIC_TWEET } from '@graphql/tweet';
 interface Props {
   displayModal: boolean;
   onClickCloseBtn: () => void;
+  updateQuery?: { query: DocumentNode; variables?: {}; object?: boolean };
 }
 
-const NewTweetModal: FunctionComponent<Props> = ({ displayModal, onClickCloseBtn }) => {
+const NewTweetModal: FunctionComponent<Props> = ({
+  displayModal,
+  onClickCloseBtn,
+  updateQuery,
+}) => {
   const [addBasicTweet, { loading: mutationLoading, error: mutationError }] = useMutation(
     ADD_BASIC_TWEET,
   );
   return (
     <Modal displayModal={displayModal} onClickCloseBtn={onClickCloseBtn}>
-      <NewTweetContainer onClickQuery={addBasicTweet} onClickCloseBtn={onClickCloseBtn} />
+      <NewTweetContainer
+        onClickQuery={addBasicTweet}
+        onClickCloseBtn={onClickCloseBtn}
+        updateQuery={updateQuery}
+      />
     </Modal>
   );
 };

--- a/fe/src/components/organisms/UserDetailContainer/index.tsx
+++ b/fe/src/components/organisms/UserDetailContainer/index.tsx
@@ -66,7 +66,7 @@ const UserDetailContainer: FunctionComponent<Props> = ({ children, userId }) => 
           <UserFollowContainer>
             <Link href={`/${user.user_id}/follow/`}>
               <a>
-                <TitleSubText title="팔로워 수" sub={followerCount ? followerCount.count : 0} />
+                <TitleSubText title="팔로워 수" sub={followerCount?.count} />
               </a>
             </Link>
             <Link href={`/${user.user_id}/follow/following`}>

--- a/fe/src/hooks/useHomeTweetListInfiniteScroll.ts
+++ b/fe/src/hooks/useHomeTweetListInfiniteScroll.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@apollo/client';
 import { useInfiniteScroll } from '@hooks';
 import { GET_TWEETLIST } from '@graphql/tweet';
 
-const ONE_MINUTE = 60 * 1000;
+const THIRTY_SECONDS = 30 * 1000;
 
 const useHomeTweetInfiniteScroll = (
   fetchMoreEl: React.RefObject<HTMLDivElement>,
@@ -18,7 +18,7 @@ const useHomeTweetInfiniteScroll = (
   const { _id: bottomTweetId } = data?.tweetList[data?.tweetList.length - 1] || {};
   useQuery(GET_TWEETLIST, {
     variables: { latestTweetId: topTweetId },
-    pollInterval: ONE_MINUTE,
+    pollInterval: THIRTY_SECONDS,
   });
 
   const [intersecting, setIntersecting, loadFinished, setLoadFinished] = useInfiniteScroll(

--- a/fe/src/pages/[userId]/[[...type]].tsx
+++ b/fe/src/pages/[userId]/[[...type]].tsx
@@ -67,7 +67,7 @@ const UserDetail: FunctionComponent = () => {
   }, [userId]);
 
   return (
-    <PageLayout>
+    <PageLayout updateQuery={{ query: GET_USER_TWEETLIST, variables: { userId } }}>
       <UserDetailContainer userId={userId as string} />
       <TabBar
         value={value}
@@ -80,7 +80,10 @@ const UserDetail: FunctionComponent = () => {
             <TweetContainer
               key={index}
               tweet={tweet}
-              updateQuery={{ query: keyValue[value].updateQuery }}
+              updateQuery={{
+                query: keyValue[value].updateQuery,
+                variables: { userId: keyValue[value].variableValue },
+              }}
             />
           ))
         ) : (

--- a/fe/src/pages/explore/[[...type]].tsx
+++ b/fe/src/pages/explore/[[...type]].tsx
@@ -75,7 +75,10 @@ const Explore: FunctionComponent = () => {
   };
 
   return (
-    <PageLayout page="탐색하기">
+    <PageLayout
+      page="탐색하기"
+      updateQuery={{ query: GET_SEARCH_TWEETLIST, variables: { searchWord } }}
+    >
       <SearchBar
         placeholder="Search Twitter"
         type="text"


### PR DESCRIPTION
### 📕 Issue Number

Close #

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 페이지레이아웃에 updateQuery를 Props로 줌으로 페이지에 맞는 쿼리문 업데이트
- [x] 댓글시 트윗 사라지는 에러
     - 댓글 입력시 fetchMore로 데이터를 받아오는데 userId 가 없어 데이터를 받아오지못해서 발생한 에러
     - variables 로 userId값 추가
- [x] 새 트윗 pull 주기 30초, 알림 pull 주기 10초로 변경
- [x] follower count가 null일때 팔로워 추가 됬을 때 에러 발생
     - null값에 1을 더해서 에러 발생하여 백엔드에서 null일때 0을 반환

### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 로컬에서 빌드 후 동작시 에러 발견 X
- 현재 안되는 기능 ( 알림에서 하트 누르기, 삭제시 댓글 카운트 제거, 유저 상세에서 tweets 탭에서 댓글 작성시 tweets & reply 탭에 자동으로 업데이트 안되는 문제)
- 내일 해야 할 것 데이터가 없을 때 알림 텍스트 구현, 검색바 크기 조절, margin, padding UI 수정, nignx 로 80번 포트로 변경, 라우팅 변경 (도메인 사용으로 인해), dns 사용으로 인해 cors 옵션 추가 

<br/><br/>
