### PR TITLE
[fix] 트윗 삭제시 댓글 수, 리트윗 수 줄어들지 않는 에러 해결 및 css 수정

### DIFF
--- a/fe/src/components/atoms/NoResult/index.tsx
+++ b/fe/src/components/atoms/NoResult/index.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+import Container from './styled';
+
+interface Props {
+  value: string;
+  start: string;
+  end: string;
+}
+
+const NoResult: FunctionComponent<Props> = ({ start, value, end }) => {
+  const string = `${start} ${value} ${end}`;
+  return <Container>{string}</Container>;
+};
+
+export default NoResult;

--- a/fe/src/components/atoms/NoResult/styled.ts
+++ b/fe/src/components/atoms/NoResult/styled.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  text-align: center;
+  font-weight: 600px;
+  font-size: 25px;
+`;
+
+export default Container;

--- a/fe/src/components/atoms/index.ts
+++ b/fe/src/components/atoms/index.ts
@@ -18,6 +18,7 @@ import Label from './Label';
 import ProfileImg from './ProfileImg';
 import Text from './Text';
 import TextArea from './TextArea';
+import NoResult from './NoResult';
 
 export {
   Form,
@@ -38,4 +39,5 @@ export {
   ProfileImg,
   Text,
   TextArea,
+  NoResult,
 };

--- a/fe/src/components/organisms/NewTweetContainer/index.tsx
+++ b/fe/src/components/organisms/NewTweetContainer/index.tsx
@@ -57,7 +57,7 @@ const NewTweetContainer: FunctionComponent<Props> = ({
     let source;
     if (updateQuery.object) {
       source = { ...tweet };
-      const number = source[type] + 1;
+      const number = (source[type] || 0) + 1;
       source = { ...source, [type]: number };
     } else {
       const res = cache.readQuery<{ tweetList: TweetType[] }>(query);

--- a/fe/src/components/organisms/NotificationContainer/FollowContainer/styled.ts
+++ b/fe/src/components/organisms/NotificationContainer/FollowContainer/styled.ts
@@ -5,6 +5,7 @@ const BodyContainer = styled.div`
 `;
 const Container = styled.div`
   display: flex;
+  margin: 10px;
 `;
 
 export { BodyContainer, Container };

--- a/fe/src/components/organisms/TweetContainer/index.tsx
+++ b/fe/src/components/organisms/TweetContainer/index.tsx
@@ -40,6 +40,20 @@ const TweetContainer: FunctionComponent<Props> = ({ tweet, updateQuery }) => {
       if (tweetCache) {
         const updateData = [...tweetCache.tweetList];
         const idx = binarySearch(updateData, tweet._id);
+        if (updateData[idx].parent_id) {
+          const retweetIdx = binarySearch(updateData, updateData[idx].parent_id);
+          if (retweetIdx !== -1) {
+            const number = updateData[retweetIdx].child_tweet_number - 1;
+            updateData[retweetIdx] = { ...updateData[retweetIdx], child_tweet_number: number };
+          }
+        }
+        if (updateData[idx].retweet_id) {
+          const retweetIdx = binarySearch(updateData, updateData[idx].retweet_id);
+          if (retweetIdx !== -1) {
+            const number = updateData[retweetIdx].retweet_user_number - 1;
+            updateData[retweetIdx] = { ...updateData[retweetIdx], retweet_user_number: number };
+          }
+        }
         if (idx === -1) return;
         updateData.splice(idx, 1);
         cache.writeQuery({
@@ -101,4 +115,5 @@ const TweetContainer: FunctionComponent<Props> = ({ tweet, updateQuery }) => {
     </>
   );
 };
+
 export default TweetContainer;

--- a/fe/src/graphql/tweet/getTweet.ts
+++ b/fe/src/graphql/tweet/getTweet.ts
@@ -13,6 +13,7 @@ export const GET_TWEETLIST = gql`
       retweet_user_number
       heart_user_number
       retweet_id
+      parent_id
       img_url_list
       retweet {
         _id
@@ -47,6 +48,7 @@ export const GET_USER_TWEETLIST = gql`
       retweet_user_number
       heart_user_number
       retweet_id
+      parent_id
       img_url_list
       retweet {
         _id
@@ -81,6 +83,7 @@ export const GET_USER_ALL_TWEETLIST = gql`
       retweet_user_number
       heart_user_number
       retweet_id
+      parent_id
       img_url_list
       retweet {
         _id
@@ -116,6 +119,7 @@ export const GET_TWEET_DETAIL = gql`
       retweet_user_number
       heart_user_number
       retweet_id
+      parent_id
       img_url_list
       retweet {
         _id
@@ -150,6 +154,7 @@ export const GET_CHILD_TWEETLIST = gql`
       retweet_user_number
       heart_user_number
       retweet_id
+      parent_id
       img_url_list
       retweet {
         _id
@@ -186,6 +191,7 @@ export const GET_SEARCH_TWEETLIST = gql`
       img_url_list
       heart_user_number
       retweet_id
+      parent_id
       retweet {
         _id
         content
@@ -220,6 +226,7 @@ export const GET_HEART_TWEETLIST = gql`
       heart_user_number
       img_url_list
       retweet_id
+      parent_id
       retweet {
         _id
         content

--- a/fe/src/pages/[userId]/[[...type]].tsx
+++ b/fe/src/pages/[userId]/[[...type]].tsx
@@ -67,7 +67,7 @@ const UserDetail: FunctionComponent = () => {
   }, [userId]);
 
   return (
-    <PageLayout updateQuery={{ query: GET_USER_TWEETLIST, variables: { userId } }}>
+    <PageLayout updateQuery={{ query: keyValue[value].updateQuery, variables: { userId } }}>
       <UserDetailContainer userId={userId as string} />
       <TabBar
         value={value}

--- a/fe/src/pages/[userId]/[[...type]].tsx
+++ b/fe/src/pages/[userId]/[[...type]].tsx
@@ -6,6 +6,7 @@ import { useDataWithInfiniteScroll, useTypeRouter } from '@hooks';
 import { initializeApollo, getJWTFromBrowser } from '@libs';
 import { GET_USER_TWEETLIST, GET_USER_ALL_TWEETLIST, GET_HEART_TWEETLIST } from '@graphql/tweet';
 import DETAIL_PAGE from '@graphql/custom';
+import { NoResult } from '@atoms';
 import { TweetType } from '@types';
 
 const getValue = (type?: string[] | string) => {
@@ -57,14 +58,13 @@ const UserDetail: FunctionComponent = () => {
     if (newValue !== value) {
       if (newValue === 'tweets') newValue = '';
       router.replace('/[userId]/[type]', `/${userId}/${newValue}`, { shallow: true });
+      apolloClient.cache.evict({ id: 'ROOT_QUERY', fieldName: 'user_all_tweet_list' });
+      apolloClient.cache.evict({ id: 'ROOT_QUERY', fieldName: 'heart_tweet_list' });
+      apolloClient.cache.evict({ id: 'ROOT_QUERY', fieldName: 'user_tweet_list' });
       setLoadFinished(false);
       setIntersecting(false);
     }
   };
-  useEffect(() => {
-    apolloClient.cache.evict({ id: 'ROOT_QUERY', fieldName: 'user_all_tweet_list' });
-    apolloClient.cache.evict({ id: 'ROOT_QUERY', fieldName: 'heart_tweet_list' });
-  }, [userId]);
 
   return (
     <PageLayout updateQuery={{ query: keyValue[value].updateQuery, variables: { userId } }}>
@@ -89,7 +89,9 @@ const UserDetail: FunctionComponent = () => {
         ) : (
           <></>
         )}
-        {data?.tweetList?.length === 0 ? <div>팔로우 x </div> : null}
+        {data?.tweetList?.length === 0 ? (
+          <NoResult start="You don’t have any" value={value} end="yet" />
+        ) : null}
       </div>
       <LoadingCircle loadFinished={loadFinished} fetchMoreEl={fetchMoreEl} />
     </PageLayout>

--- a/fe/src/pages/[userId]/follow/[[...type]].tsx
+++ b/fe/src/pages/[userId]/follow/[[...type]].tsx
@@ -6,6 +6,7 @@ import { useTypeRouter, useDataWithInfiniteScroll } from '@hooks';
 import { GET_FOLLOWING_LIST, GET_FOLLOWER_LIST } from '@graphql/user';
 import { UserType } from '@types';
 import { getJWTFromBrowser, initializeApollo } from '@libs';
+import { NoResult } from '@atoms';
 import UserBox from './styled';
 
 const getValue = (type?: string[] | string) => {
@@ -72,9 +73,11 @@ const Follow: FunctionComponent = () => {
             ),
           )
         ) : (
-          <ComponentLoading />
+          <></>
         )}
-        {data?.list?.length === 0 ? <div>팔로우 x </div> : null}
+        {data?.list?.length === 0 ? (
+          <NoResult start="You aren’t" value={value} end="anyone yet" />
+        ) : null}
       </div>
       <LoadingCircle loadFinished={loadFinished} fetchMoreEl={fetchMoreEl} />
     </PageLayout>

--- a/fe/src/pages/explore/[[...type]].tsx
+++ b/fe/src/pages/explore/[[...type]].tsx
@@ -7,6 +7,7 @@ import { useOnTextChange, useTypeRouter, useDataWithInfiniteScroll } from '@hook
 import { initializeApollo, getJWTFromBrowser } from '@libs';
 import { GET_SEARCH_TWEETLIST } from '@graphql/tweet';
 import { GET_SEARCH_USERLIST } from '@graphql/user';
+import { NoResult } from '@atoms';
 import { TweetType, UserType } from '@types';
 
 const getValue = (type?: string[] | string) => {
@@ -79,14 +80,16 @@ const Explore: FunctionComponent = () => {
       page="탐색하기"
       updateQuery={{ query: GET_SEARCH_TWEETLIST, variables: { searchWord } }}
     >
-      <SearchBar
-        placeholder="Search Twitter"
-        type="text"
-        width="90%"
-        value={textValue}
-        onChange={onTextChange}
-        onKeyDown={onKeyDown}
-      />
+      <div style={{ margin: '10px' }}>
+        <SearchBar
+          placeholder="Search Twitter"
+          type="text"
+          width="100%"
+          value={textValue}
+          onChange={onTextChange}
+          onKeyDown={onKeyDown}
+        />
+      </div>
       <TabBar value={value} handleChange={onClick} labels={['tweets', 'people']} />
       <div>
         {data ? (
@@ -106,8 +109,9 @@ const Explore: FunctionComponent = () => {
         ) : (
           <></>
         )}
-        {data?.tweetList?.length === 0 ? <div>데이터 X</div> : null}
-        {data?.searchList?.length === 0 ? <div>데이터 X</div> : null}
+        {data?.tweetList?.length === 0 || data?.searchList?.length === 0 ? (
+          <NoResult start="No results for" value={value} end="" />
+        ) : null}
       </div>
       <LoadingCircle loadFinished={loadFinished} fetchMoreEl={fetchMoreEl} />
     </PageLayout>

--- a/fe/src/pages/index.tsx
+++ b/fe/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { GET_TWEETLIST, ADD_BASIC_TWEET } from '@graphql/tweet';
 import { TweetType } from '@types';
 import { initializeApollo, getJWTFromBrowser } from '@libs';
 import { LoadingCircle } from '@molecules';
+import { NoResult } from '@atoms';
 import HomeBox from './styled';
 
 const Home: FunctionComponent = () => {
@@ -22,7 +23,9 @@ const Home: FunctionComponent = () => {
         {data?.tweetList?.map((tweet: TweetType, index: number) => (
           <TweetContainer key={index} tweet={tweet} updateQuery={{ query: GET_TWEETLIST }} />
         ))}
-        {data?.tweetList?.length === 0 ? <div>데이터 x</div> : null}
+        {data?.tweetList?.length === 0 ? (
+          <NoResult start="Welcome to Twitter!" value="" end="" />
+        ) : null}
       </div>
       <LoadingCircle loadFinished={loadFinished} fetchMoreEl={fetchMoreEl} />
     </PageLayout>

--- a/fe/src/pages/notifications/[[...type]].tsx
+++ b/fe/src/pages/notifications/[[...type]].tsx
@@ -7,6 +7,7 @@ import { useDataWithInfiniteScroll, useTypeRouter } from '@hooks';
 import { initializeApollo, getJWTFromBrowser } from '@libs';
 import { GET_MYINFO } from '@graphql/user';
 import { NotificationType, UserType } from '@types';
+import { NoResult } from '@atoms';
 import {
   GET_NOTIFICATION_LIST,
   GET_MENTION_NOTIFICATION_LIST,
@@ -98,7 +99,9 @@ const Notification: FunctionComponent = () => {
             updateQuery={{ query: keyValue[value].updateQuery }}
           />
         ))}
-        {data?.notifications?.length === 0 ? <div>데이터 x</div> : null}
+        {data?.notifications?.length === 0 ? (
+          <NoResult start="You don’t have any" value="notification" end="yet" />
+        ) : null}
       </>
       <LoadingCircle loadFinished={loadFinished} fetchMoreEl={fetchMoreEl} />
     </PageLayout>

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -31,6 +31,7 @@ interface TweetType {
   author: UserType;
   retweet_id: string;
   retweet: TweetType;
+  parent_id: string;
 }
 
 interface NotificationType {


### PR DESCRIPTION
### 📕 Issue Number

Close #

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 트윗 삭제시 부모 트윗에서 댓글 개수, 리트윗 개수 줄어들게 캐시 업데이트
- [x] 탭이동마다 캐시를 비워 항상 최신데이터 업데이트 
- [x] 데이터 없을 때 텍스트 나타나게 변경 ( 페이지에 맞게, css 추가하면 좋을 듯)
- [x] 검색바, 알림 팔로우 컨테이너 margin 조절

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항
> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 최신데이터를 유지할 지 아니면 조금 늦게 해도 상관없을지 이야기 : 탭이동간 캐시를 지워주면 최신데이터 유지가능, 그러나 항상 데이터 패칭을 해와야함. 현재 캐시 지워줘 데이터 패칭되게 되있는상태

- 아래처럼 데이터 없을 때 처리, 페이지마다 문구 조금씩 다름

![캡처](https://user-images.githubusercontent.com/46195613/102459612-2cb9bf80-4089-11eb-9c5c-4c791ba2ff54.PNG)

<br/><br/>
